### PR TITLE
Add support for mklink with junctions

### DIFF
--- a/src/nvm.go
+++ b/src/nvm.go
@@ -44,32 +44,34 @@ import (
 var NvmVersion = ""
 
 type Environment struct {
-	settings        string
-	root            string
-	symlink         string
-	arch            string
-	node_mirror     string
-	npm_mirror      string
-	proxy           string
-	originalpath    string
-	originalversion string
-	verifyssl       bool
+	settings         string
+	root             string
+	symlink          string
+	symlink_junction bool
+	arch             string
+	node_mirror      string
+	npm_mirror       string
+	proxy            string
+	originalpath     string
+	originalversion  string
+	verifyssl        bool
 }
 
 var home = filepath.Clean(os.Getenv("NVM_HOME") + "\\settings.txt")
 var symlink = filepath.Clean(os.Getenv("NVM_SYMLINK"))
 
 var env = &Environment{
-	settings:        home,
-	root:            "",
-	symlink:         symlink,
-	arch:            strings.ToLower(os.Getenv("PROCESSOR_ARCHITECTURE")),
-	node_mirror:     "",
-	npm_mirror:      "",
-	proxy:           "none",
-	originalpath:    "",
-	originalversion: "",
-	verifyssl:       true,
+	settings:         home,
+	root:             "",
+	symlink:          symlink,
+	symlink_junction: false,
+	arch:             strings.ToLower(os.Getenv("PROCESSOR_ARCHITECTURE")),
+	node_mirror:      "",
+	npm_mirror:       "",
+	proxy:            "none",
+	originalpath:     "",
+	originalversion:  "",
+	verifyssl:        true,
 }
 
 func writeToErrorLog(i interface{}, abort ...bool) {
@@ -1194,10 +1196,18 @@ func use(version string, cpuarch string, reload ...bool) {
 		// Create new symlink
 		var ok bool
 		// ok, err = runElevated(fmt.Sprintf(`"%s" cmd /C mklink /D "%s" "%s"`, filepath.Join(env.root, "elevate.cmd"), filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version)))
-		ok, err = elevatedRun("mklink", "/D", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+		if env.symlink_junction {
+			ok, err = elevatedRun("mklink", "/J", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+		} else {
+			ok, err = elevatedRun("mklink", "/D", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+		}
 		if err != nil {
 			if strings.Contains(err.Error(), "not have sufficient privilege") || strings.Contains(strings.ToLower(err.Error()), "access is denied") {
-				ok, err = elevatedRun("mklink", "/D", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+				if env.symlink_junction {
+					ok, err = elevatedRun("mklink", "/J", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+				} else {
+					ok, err = elevatedRun("mklink", "/D", filepath.Clean(env.symlink), filepath.Join(env.root, "v"+version))
+				}
 				if err != nil {
 					ok = false
 					status <- Status{Err: err, Done: true}
@@ -2024,6 +2034,9 @@ func setup() {
 	}
 	if val, ok := m["npm_mirror"]; ok {
 		env.npm_mirror = val
+	}
+	if val, ok := m["symlink_junction"]; ok {
+		env.symlink_junction = val == strconv.FormatBool(true)
 	}
 
 	if val, ok := m["proxy"]; ok {


### PR DESCRIPTION
Additional mode of work with support for NTFS junction points. It allows user to create link between directories when permission to create directory symlinks is denied. Fixes bug #79 

To enable the option simply put the configuration in your nvm settings.txt. (option is disabled by default to keep the compatibility.
```txt
symlink_junction: true
```

Please review well the PR, it is my first time with golang ;)
Developed with golang 1.22.3 in mind.
Tested and verified on the restricted machine. 🆗 
Tested and verified on the unrestricted machine. 🆗 